### PR TITLE
Add multi-select support for running multiple tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,24 @@
         "tooltip": "Debug this test"
       },
       {
+        "command": "django-test-manager.runSelectedTests",
+        "title": "Run Selected Tests",
+        "icon": "$(play)",
+        "tooltip": "Run all selected tests"
+      },
+      {
+        "command": "django-test-manager.copyTestCommand",
+        "title": "Copy Test Command",
+        "icon": "$(copy)",
+        "tooltip": "Copy Django test command for selected tests"
+      },
+      {
+        "command": "django-test-manager.previewTestCommand",
+        "title": "Preview Test Command",
+        "icon": "$(info)",
+        "tooltip": "Preview Django test command for selected tests"
+      },
+      {
         "command": "django-test-manager.copyPath",
         "title": "Copy Path",
         "icon": "$(copy)",
@@ -230,11 +248,18 @@
         },
         {
           "command": "django-test-manager.runTest",
-          "when": "view == djangoTestExplorer"
+          "when": "view == djangoTestExplorer && !djangoTestManager.hasMultipleSelection",
+          "group": "1_run@1"
+        },
+        {
+          "command": "django-test-manager.runSelectedTests",
+          "when": "view == djangoTestExplorer && djangoTestManager.hasMultipleSelection",
+          "group": "1_run@2"
         },
         {
           "command": "django-test-manager.debugTest",
-          "when": "view == djangoTestExplorer"
+          "when": "view == djangoTestExplorer && !djangoTestManager.hasMultipleSelection",
+          "group": "1_run@3"
         },
         {
           "command": "django-test-manager.copyPath",
@@ -243,7 +268,18 @@
         },
         {
           "command": "django-test-manager.copyPath",
-          "when": "view == djangoTestExplorer"
+          "when": "view == djangoTestExplorer && !djangoTestManager.hasMultipleSelection",
+          "group": "2_copy@1"
+        },
+        {
+          "command": "django-test-manager.copyTestCommand",
+          "when": "view == djangoTestExplorer && djangoTestManager.hasMultipleSelection",
+          "group": "2_copy@2"
+        },
+        {
+          "command": "django-test-manager.previewTestCommand",
+          "when": "view == djangoTestExplorer && djangoTestManager.hasMultipleSelection",
+          "group": "2_copy@3"
         }
       ],
       "editor/title": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { TestDecorationProvider } from './testDecorations';
 import { TestStatusBar } from './testStatusBar';
 import { TestStateManager } from './testStateManager';
 import { CoverageProvider } from './coverageProvider';
-import { getMergedEnvironmentVariables, initTestUtilsCache, resolvePath } from './testUtils';
+import { getMergedEnvironmentVariables, initTestUtilsCache, resolvePath, normalizeTestPaths } from './testUtils';
 import { WatchModeManager } from './watchMode';
 import { TestHistoryManager, TestHistoryTreeProvider } from './testHistory';
 import { isTestClassFromLine } from './testUtils';
@@ -43,8 +43,17 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Use createTreeView to get access to the view instance
     const treeView = vscode.window.createTreeView('djangoTestExplorer', {
-        treeDataProvider: testTreeDataProvider
+        treeDataProvider: testTreeDataProvider,
+        canSelectMany: true
     });
+
+    // Handle tree selection changes
+    context.subscriptions.push(
+        treeView.onDidChangeSelection(e => {
+            const hasMultipleSelection = e.selection.length > 1;
+            vscode.commands.executeCommand('setContext', 'djangoTestManager.hasMultipleSelection', hasMultipleSelection);
+        })
+    );
 
     // Status Bar
     const statusBar = new TestStatusBar();
@@ -83,6 +92,58 @@ export function activate(context: vscode.ExtensionContext) {
             } else if ((item as TestNode).dottedPath) {
                 testRunner.runInTerminal(item as TestNode);
             }
+        }),
+        vscode.commands.registerCommand('django-test-manager.runSelectedTests', (_item: TestItem, selectedItems?: TestItem[]) => {
+            const items = selectedItems && selectedItems.length > 0 ? selectedItems : treeView.selection;
+            if (!items || items.length === 0) {
+                vscode.window.showInformationMessage('No tests selected.');
+                return;
+            }
+
+            const paths = items.map(item => item.node.dottedPath).filter((p): p is string => p !== undefined);
+            const normalizedPaths = normalizeTestPaths(paths);
+
+            const nodesToRun = normalizedPaths.map(p => {
+                const item = items.find(i => i.node.dottedPath === p);
+                return item ? item.node : { name: p.split('.').pop() || p, type: 'folder', dottedPath: p } as TestNode;
+            });
+
+            if (nodesToRun.length > 0) {
+                testRunner.runInTerminal(nodesToRun);
+            }
+        }),
+        vscode.commands.registerCommand('django-test-manager.copyTestCommand', (_item: TestItem, selectedItems?: TestItem[]) => {
+            const items = selectedItems && selectedItems.length > 0 ? selectedItems : treeView.selection;
+            if (!items || items.length === 0) {
+                vscode.window.showInformationMessage('No tests selected.');
+                return;
+            }
+
+            const paths = items.map(item => item.node.dottedPath).filter((p): p is string => p !== undefined);
+            const normalizedPaths = normalizeTestPaths(paths);
+            const { cmd, args } = testRunner.buildTestCommandParts(normalizedPaths);
+
+            // Build display command string responsibly
+            const fullCmd = `${cmd} ${args.map((a: string) => a.includes(' ') ? `"${a}"` : a).join(' ')}`;
+
+            vscode.env.clipboard.writeText(fullCmd);
+            vscode.window.showInformationMessage('Test command copied to clipboard');
+        }),
+        vscode.commands.registerCommand('django-test-manager.previewTestCommand', (_item: TestItem, selectedItems?: TestItem[]) => {
+            const items = selectedItems && selectedItems.length > 0 ? selectedItems : treeView.selection;
+            if (!items || items.length === 0) {
+                vscode.window.showInformationMessage('No tests selected.');
+                return;
+            }
+
+            const paths = items.map(item => item.node.dottedPath).filter((p): p is string => p !== undefined);
+            const normalizedPaths = normalizeTestPaths(paths);
+            const { cmd, args } = testRunner.buildTestCommandParts(normalizedPaths);
+
+            // Build display command string responsibly
+            const fullCmd = `${cmd} ${args.map((a: string) => a.includes(' ') ? `"${a}"` : a).join(' ')}`;
+
+            vscode.window.showInformationMessage(`Command: ${fullCmd}`, { modal: true });
         }),
         vscode.commands.registerCommand('django-test-manager.debugTest', async (item: TestItem | TestNode) => {
             const node = item instanceof TestItem ? item.node : item;

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -33,9 +33,11 @@ export class TestRunner {
         });
     }
 
-    async run(node: TestNode): Promise<void> {
-        const testPath = node.dottedPath;
-        if (!testPath) {
+    async run(node: TestNode | TestNode[]): Promise<void> {
+        const nodes = Array.isArray(node) ? node : [node];
+        const testPaths = nodes.map((n) => n.dottedPath).filter((p): p is string => p !== undefined && p !== null);
+
+        if (testPaths.length === 0) {
             vscode.window.showErrorMessage("Could not determine test path");
             return;
         }
@@ -44,11 +46,11 @@ export class TestRunner {
         TestStateManager.getInstance().clear();
 
         // Reset status
-        this.setNodeStatus(node, "pending");
+        nodes.forEach(n => this.setNodeStatus(n, "pending"));
         this.outputChannel.clear();
         this.outputChannel.show();
 
-        const { cmd, args } = this.buildTestCommandParts(testPath);
+        const { cmd, args } = this.buildTestCommandParts(testPaths);
 
         // Build display command string responsibly
         const fullCmd = `${cmd} ${args.map(a => a.includes(' ') ? `"${a}"` : a).join(' ')}`;
@@ -56,10 +58,12 @@ export class TestRunner {
 
         const env = await getMergedEnvironmentVariables(this.workspaceRoot);
 
+        const testName = nodes.length === 1 ? nodes[0].name : "Selected Tests";
+
         return vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Running tests for ${node.name}...`,
+                title: `Running tests for ${testName}...`,
                 cancellable: true,
             },
             (progress, token) => {
@@ -102,7 +106,13 @@ export class TestRunner {
                                 `\nProcess exited with code: ${code}`
                             );
                         }
-                        this.parseResults(node, buffer);
+                        const combinedNode: TestNode = {
+                            name: "Combined Tests",
+                            type: "folder",
+                            dottedPath: "",
+                            children: nodes
+                        };
+                        this.parseResults(combinedNode, buffer);
                         resolve();
                     });
 
@@ -163,9 +173,11 @@ export class TestRunner {
     private failureBlock: string[] = [];
     private testStartTimes: Map<string, number> = new Map();
 
-    async runInTerminal(node: TestNode): Promise<void> {
-        const testPath = node.dottedPath;
-        if (testPath === undefined || testPath === null) {
+    async runInTerminal(node: TestNode | TestNode[]): Promise<void> {
+        const nodes = Array.isArray(node) ? node : [node];
+        const testPaths = nodes.map((n) => n.dottedPath).filter((p): p is string => p !== undefined && p !== null);
+
+        if (testPaths.length === 0) {
             vscode.window.showErrorMessage("Could not determine test path");
             return;
         }
@@ -187,9 +199,9 @@ export class TestRunner {
             }
         };
 
-        let effectiveNode = node;
+        let effectiveNode: TestNode;
 
-        if (!node.dottedPath) {
+        if (nodes.length === 1 && !nodes[0].dottedPath) {
             // Run All case: Set everything to pending
             const roots = await this.treeDataProvider.getChildren();
             roots.forEach((rootItem) => setPendingRecursive(rootItem.node));
@@ -202,16 +214,26 @@ export class TestRunner {
                 children: roots.map((r) => r.node),
             };
         } else {
-            // Specific node case
-            const realNode = await this.treeDataProvider.findNode(node.dottedPath);
-            const nodeToUpdate = realNode || node;
-            setPendingRecursive(nodeToUpdate);
-            effectiveNode = nodeToUpdate;
+            // Specific node(s) case
+            const realNodes = await Promise.all(nodes.map(n => this.treeDataProvider.findNode(n.dottedPath!)));
+            const nodesToUpdate = realNodes.map((n, i) => n || nodes[i]);
+            nodesToUpdate.forEach(n => setPendingRecursive(n));
+
+            if (nodesToUpdate.length === 1) {
+                effectiveNode = nodesToUpdate[0];
+            } else {
+                effectiveNode = {
+                    name: "Selected Tests",
+                    type: "folder",
+                    dottedPath: "",
+                    children: nodesToUpdate
+                };
+            }
         }
 
         this.treeDataProvider.refresh();
 
-        const { cmd, args } = this.buildTestCommandParts(testPath);
+        const { cmd, args } = this.buildTestCommandParts(testPaths);
         await this.executeCommandInTerminal(cmd, args, effectiveNode);
     }
 
@@ -232,8 +254,7 @@ export class TestRunner {
         });
         this.treeDataProvider.refresh();
 
-        const testPaths = failedTests.join(" ");
-        const { cmd, args } = this.buildTestCommandParts(testPaths);
+        const { cmd, args } = this.buildTestCommandParts(failedTests);
 
         // Create a dummy node for the watcher
         const effectiveNode: TestNode = {
@@ -246,7 +267,7 @@ export class TestRunner {
         await this.executeCommandInTerminal(cmd, args, effectiveNode);
     }
 
-    private buildTestCommandParts(testPaths: string): { cmd: string, args: string[] } {
+    public buildTestCommandParts(testPaths: string[]): { cmd: string, args: string[] } {
         const config = vscode.workspace.getConfiguration("djangoTestManager");
         let pythonPath = config.get<string>("pythonPath") || "python3";
         const managePyPathConfig = config.get<string>("managePyPath") || "manage.py";
@@ -319,8 +340,9 @@ export class TestRunner {
             } else if (token === '${managePyPath}') {
                 finalArgs.push(managePyPath);
             } else if (token === '${testPath}') {
-                if (testPaths.trim().length > 0) {
-                    finalArgs.push(...testPaths.split(' '));
+                const validPaths = testPaths.filter(p => p.trim().length > 0);
+                if (validPaths.length > 0) {
+                    finalArgs.push(...validPaths);
                 }
             } else if (token === '${testArguments}') {
                 finalArgs.push(...testArgs);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -264,3 +264,29 @@ export function resolvePath(pathValue: string, workspaceRoot: string, defaultPat
     // Otherwise, resolve it relative to workspaceRoot
     return path.resolve(workspaceRoot, resolvedPath);
 }
+
+/**
+ * Normalizes and deduplicates a list of test dotted paths.
+ * If a path is a child of another path in the list, it is removed.
+ * Example: ['app1', 'app1.tests'] -> ['app1']
+ * @param paths Array of dotted paths to normalize
+ * @returns Deduplicated array of dotted paths
+ */
+export function normalizeTestPaths(paths: string[]): string[] {
+    if (!paths || paths.length === 0) return [];
+
+    // Sort paths by length so that shorter paths (parents) come first
+    const sortedPaths = [...paths].filter(p => p).sort((a, b) => a.length - b.length);
+    const normalized: string[] = [];
+
+    for (const p of sortedPaths) {
+        // Check if any existing path in normalized is a parent of p
+        // It's a parent if p starts with normalizedPath + '.'
+        const isChild = normalized.some(parent => p === parent || p.startsWith(`${parent}.`));
+        if (!isChild) {
+            normalized.push(p);
+        }
+    }
+
+    return normalized;
+}


### PR DESCRIPTION
Implemented Phase 1 of the multi-select execution epic. Users can now select multiple nodes in the Test Explorer tree view (apps, files, methods, etc.), preview their combined command execution string, copy it, and execute it efficiently inside a single Django `manage.py test` process. 

Test selection paths are normalized to eliminate duplicates and redundant child paths if a parent is already selected.

---
*PR created automatically by Jules for task [9414040138362623740](https://jules.google.com/task/9414040138362623740) started by @viseshagarwal*